### PR TITLE
always return a value

### DIFF
--- a/scroll-workspaces/extension.js
+++ b/scroll-workspaces/extension.js
@@ -52,11 +52,12 @@ Ext.prototype = {
 		} else if (direction == Clutter.ScrollDirection.UP) {
 			diff = -1;
 		} else {
-			return;
+			return false;
 		}
 
 		let newIndex = global.screen.get_active_workspace().index() + diff;
 		this._activate(newIndex);
+		return true;
 	},
 }
 


### PR DESCRIPTION
fix warning message
Window manager warning: Log level 32: JS WARNING: [.../.local/share/gnome-shell/extensions/scroll-workspaces@gfxmonk.net/extension.js 55]: anonymous function does not always return a value
