### PR TITLE
Fix for different workspace layouts

### DIFF
--- a/scroll-workspaces/extension.js
+++ b/scroll-workspaces/extension.js
@@ -92,10 +92,12 @@ Ext.prototype = {
 		let motion;
 		switch (event.get_scroll_direction()) {
 		case Clutter.ScrollDirection.UP:
-			motion = Meta.MotionDirection.LEFT;
+			motion = (global.workspace_manager.layout_rows == 1) ?
+				Meta.MotionDirection.LEFT : Meta.MotionDirection.UP;
 			break;
 		case Clutter.ScrollDirection.DOWN:
-			motion = Meta.MotionDirection.RIGHT;
+			motion = (global.workspace_manager.layout_rows == 1) ?
+				Meta.MotionDirection.RIGHT : Meta.MotionDirection.DOWN;
 			break;
 		case Clutter.ScrollDirection.LEFT:
 			motion = Meta.MotionDirection.LEFT;


### PR DESCRIPTION
Hi! I am developing an extension to bring back vertical workspaces in gnome-40. Someone created an [issue](https://github.com/RensAlthuis/vertical-overview/issues/17) that it unfortunately breaks your extension. This not something I can fix on my end, so would you consider these changes?

This idea is that whenever the layout has a single row (like base gnome-40 is now), scrolling up and down should act the same as left and right. For any other case such as with workspace-grid pre-gnome-40 or with my extension active, the normal behaviour is preferred. I think that this will work for pretty much all cases.