### PR TITLE
Fix workspace indicator in Gnome 43+

### DIFF
--- a/scroll-workspaces/extension.js
+++ b/scroll-workspaces/extension.js
@@ -168,7 +168,7 @@ Ext.prototype = {
 			// Do not show wokspaceSwithcer in overview
 			if(!Main.overview.visible) {
 				// Fix for Gnome 43+
-				if(imports.misc.config.PACKAGE_VERSION >= '42') {
+				if(parseInt(imports.misc.config.PACKAGE_VERSION) >= 42) {
 					Main.wm._workspaceSwitcherPopup.display(ws.index());
 				} else {
 					Main.wm._workspaceSwitcherPopup.display(motion, ws.index());

--- a/scroll-workspaces/extension.js
+++ b/scroll-workspaces/extension.js
@@ -166,8 +166,14 @@ Ext.prototype = {
 				});
 
 			// Do not show wokspaceSwithcer in overview
-			if(!Main.overview.visible)
-				Main.wm._workspaceSwitcherPopup.display(motion, ws.index());
+			if(!Main.overview.visible) {
+				// Fix for Gnome 43+
+				if(imports.misc.config.PACKAGE_VERSION >= '42') {
+					Main.wm._workspaceSwitcherPopup.display(ws.index());
+				} else {
+					Main.wm._workspaceSwitcherPopup.display(motion, ws.index());
+				}
+			}
 			// End of code taken from dash-to-dock.
 		}
 


### PR DESCRIPTION
Hi !

I noticed the workspace indicator didn't have an active "dot" on Gnome 43+, so I decided to fix it.

Diagnosed the issue by comparing the code to another extension.

Cheers ! 🎉