### PR TITLE
GNOME 44

### DIFF
--- a/scroll-workspaces/metadata.json
+++ b/scroll-workspaces/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "scroll-workspaces@gfxmonk.net",
     "name": "Top Panel Workspace Scroll",
     "description": "Change workspaces by scrolling over the top panel",
-    "shell-version": [ "43" ],
+    "shell-version": [ "43", "44" ],
     "original-authors": [ "tim@gfxmonk.net" ],
     "url": "https://github.com/gfxmonk/gnome-shell-scroll-workspaces",
     "settings-schema": "org.gnome.shell.extensions.net.gfxmonk.scroll-workspaces"


### PR DESCRIPTION
Extension and its settings work on GNOME 44, tested in Fedora 38.