### PR TITLE
add charset specification

### DIFF
--- a/scroll-workspaces/locale/ru/LC_MESSAGES/scroll-workspaces.po
+++ b/scroll-workspaces/locale/ru/LC_MESSAGES/scroll-workspaces.po
@@ -1,3 +1,7 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
 #: prefs.js:29
 msgid "Ignore last workspace:"
 msgstr "Игнорировать последний рабочий стол"


### PR DESCRIPTION
Since version 0.22, msgfmt complains about missing header entry with a charset specification which causes the build to fail.